### PR TITLE
86 debugging delete review

### DIFF
--- a/tenttalk-api/src/main/java/org/codestars/tenttalk_api/controllers/ReviewController.java
+++ b/tenttalk-api/src/main/java/org/codestars/tenttalk_api/controllers/ReviewController.java
@@ -57,8 +57,9 @@ public class ReviewController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteReview(@PathVariable Long id) {
-        String response = reviewService.deleteReviewById(id);
-        return ResponseEntity.ok(response);
+        Review review = reviewRepository.findById(id).orElseThrow(() -> new RuntimeException("Review not found"));
+        reviewService.deleteReviewById(id);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/tenttalk-api/src/main/java/org/codestars/tenttalk_api/controllers/ReviewController.java
+++ b/tenttalk-api/src/main/java/org/codestars/tenttalk_api/controllers/ReviewController.java
@@ -56,9 +56,9 @@ public class ReviewController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteReview(@PathVariable Long id) {
-        reviewService.deleteReviewById(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<String> deleteReview(@PathVariable Long id) {
+        String response = reviewService.deleteReviewById(id);
+        return ResponseEntity.ok(response);
     }
 }
 

--- a/tenttalk-api/src/main/java/org/codestars/tenttalk_api/service/ReviewService.java
+++ b/tenttalk-api/src/main/java/org/codestars/tenttalk_api/service/ReviewService.java
@@ -96,7 +96,11 @@ public class ReviewService {
     public String deleteReviewById(Long id) {
         Review review = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
-
+        Campground campground = review.getCampground();
+        if (campground != null) {
+            campground.getReviews().remove(review);
+            campgroundRepository.save(campground);
+        }
         reviewRepository.delete(review);
         return "review deleted";
     }

--- a/tenttalk-api/src/main/java/org/codestars/tenttalk_api/service/ReviewService.java
+++ b/tenttalk-api/src/main/java/org/codestars/tenttalk_api/service/ReviewService.java
@@ -7,6 +7,7 @@ import org.codestars.tenttalk_api.models.Tag;
 import org.codestars.tenttalk_api.models.data.CampgroundRepository;
 import org.codestars.tenttalk_api.models.data.ReviewRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -92,11 +93,12 @@ public class ReviewService {
         return campgroundRepository.save(campground);
     }
 
-    public void deleteReviewById(Long id) {
+    public String deleteReviewById(Long id) {
         Review review = reviewRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Review not found"));
 
         reviewRepository.delete(review);
+        return "review deleted";
     }
 
     public List<Review> findAll() {


### PR DESCRIPTION
In this branch, I fixed the delete bug by replacing the broken deleteReviewById() method with an older version of the code that worked. I also set it to return a descriptive string, for debugging purposes.

To test it, use the UI to delete any review.